### PR TITLE
allow sorting and printing of MesaData objects

### DIFF
--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -120,6 +120,12 @@ class MesaData:
         self.header_names = None
         self.read_data()
 
+    def __lt__(self, other):
+        return self.star_age < other.star_age
+
+    def __str__(self):
+        return "MESA model # {:6}, t = {:20.10g} yr".format(self.model_number, self.star_age)
+
     def read_data(self):
         """Decide if data file is log output or a model, then load the data
 

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -121,10 +121,20 @@ class MesaData:
         self.read_data()
 
     def __lt__(self, other):
-        return self.star_age < other.star_age
+        try:
+            sage = float(self.star_age)
+            oage = float(other.star_age)
+            return sage < oage
+        except:
+            return self.file_name < other.file_name
 
     def __str__(self):
-        return "MESA model # {:6}, t = {:20.10g} yr".format(self.model_number, self.star_age)
+        try:
+            model_number = int(self.model_number)
+            age = float(self.star_age)
+            return "MESA model # {:6}, t = {:20.10g} yr".format(model_number, age)
+        except:
+            return "{}".format(self.file_name)
 
     def read_data(self):
         """Decide if data file is log output or a model, then load the data


### PR DESCRIPTION
These changes allow one to print and sort (by age) MESA profiles.  E.g.,

```
profiles = glob.glob("profile*0.data")
models = []
for p in profiles:
    models.append(mr.MesaData(p)

for m in sorted(models):
    print(m)
```

produces
```
MESA model #    450, t =          158677.1499 yr
MESA model #    900, t =          9371689.143 yr
MESA model #   1350, t =          934449849.7 yr
MESA model #   1850, t =          994276962.1 yr
MESA model #   2350, t =           1011636738 yr
MESA model #   2850, t =           1021325384 yr
MESA model #   3350, t =           1027557774 yr
MESA model #   3850, t =           1031542396 yr
MESA model #   4350, t =           1034313116 yr
MESA model #   4850, t =           1036342629 yr
MESA model #   5350, t =           1037887011 yr
MESA model #   5850, t =           1039104992 yr
MESA model #   6350, t =           1040087688 yr
MESA model #   6850, t =           1040898244 yr
MESA model #   7350, t =           1041578008 yr
MESA model #   7850, t =           1042156309 yr
MESA model #   8350, t =           1042653626 yr
MESA model #   8850, t =           1043085731 yr
MESA model #   9350, t =           1043465657 yr
MESA model #   9850, t =           1043801929 yr
```