### PR TITLE
Fix bug when reading .mod files which have comments

### DIFF
--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -251,7 +251,7 @@ class MesaData:
         self.header_names = []
         self.header_data = {}
         while not found_blank_line:
-            name, val = [datum.strip() for datum in lines[i].split()]
+            name, val = [datum.strip() for datum in lines[i].split()[:2]]
             self.header_data[name] = eval(pythonize_number(val))
             self.header_names.append(name)
             i += 1


### PR DESCRIPTION
Some MESA .mod files have comments in the header lines.  Example file: `mesa-r10398/star/test_suite/ns_he/ns_1.4M.mod`

```
! note: initial lines of file can contain comments
!
             4 -- model for mesa/star. cgs units. lnd=ln(density), lnT=ln(temperature), lnR=ln(radius), L=luminosity, dq=fraction of total mstar in cell; remaining cols are mass fractions.

                          M/Msun      1.4000000000198352D+00
                    model_number                               2
                        star_age      1.2858074335730455D-10
                       initial_z      2.0000000000000000D-02
                        n_shells                             918
                        net_name   'approx21.net'
                         species                              21
                          xmstar      2.1806235781705819D+24  ! mass above core (g).  mass of core:      2.7848799978588325D+33
                        R_center      1.0000000000000000D+06  ! radius of core (cm).  avg core density (g/cm^3):      6.6484112636547025D+14
                        L_center      9.9999999999999995D+33  ! luminosity of core (erg/s).  avg core eps (erg/g/s):      3.5908189967569677D+00
```

This will throw a `ValueError: too many values to unpack (expected 2)` in line 254 of `mesa_reader/__init__.py`. The simple fix is to ignore everything but the first 2 elements of the line.

(note: this "solves" Issue #14, even though in that case the extra info is not a comment and we may wish to also save it)