### PR TITLE
Use pathlib library to handle filenames

### DIFF
--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -1,7 +1,6 @@
-import os
+import os, re
 from os.path import join
-import re
-
+from pathlib import Path
 import numpy as np
 
 
@@ -172,9 +171,9 @@ class MesaData:
 
         # attempt auto-detection of file_type (if not supplied)
         if self.file_type is None:
-            if self.file_name.endswith((".data", ".log")):
+            if Path (self.file_name).suffix in [".data", ".log"]:
                 self.file_type = "log"
-            elif self.file_name.endswith(".mod"):
+            elif Path (self.file_name).suffix==".mod":
                 self.file_type = "model"
             else:
                 raise UnknownFileTypeError(


### PR DESCRIPTION
The filename that is read by the `read_data` function currently assumes that `self.file_name` is a string and checks the file suffix with the string method `endswith`. However, this prevents from passing to the function a `Path` object created e.g. with the `pathlib` library, which might prove problematic when integrating the `mesa_reader` in other module test procedure, where the path to the profile to read cannot be anything else than a `Path` object.

The fix uses the `pathlib` library in order to check the suffix of `self.file_name` (in `read_data`) with the `pathlib` library `suffix` attribute. 