### PR TITLE
Fixed crash for a single entry in history.data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ make.bat
 *.swp
 *.egg-info
 .buildinfo
+.vscode

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -6,31 +6,26 @@ import numpy as np
 
 
 class ProfileError(Exception):
-
     def __init__(self, msg):
         super().__init__(self, msg)
 
 
 class HistoryError(Exception):
-
     def __init__(self, msg):
         super().__init__(self, msg)
 
 
 class ModelNumberError(Exception):
-
     def __init__(self, msg):
         super().__init__(self, msg)
 
 
 class BadPathError(Exception):
-
     def __init__(self, msg):
         super().__init__(self, msg)
 
 
 class UnknownFileTypeError(Exception):
-
     def __init__(self, msg):
         super().__init__(self, msg)
 
@@ -143,7 +138,7 @@ class MesaData:
             sage = float(self.star_age)
             oage = float(other.star_age)
             return sage < oage
-        except:
+        except Exception:
             return self.file_name < other.file_name
 
     def __str__(self):
@@ -151,7 +146,7 @@ class MesaData:
             model_number = int(self.model_number)
             age = float(self.star_age)
             return "MESA model # {:6}, t = {:20.10g} yr".format(model_number, age)
-        except:
+        except Exception:
             return "{}".format(self.file_name)
 
     def read_data(self):
@@ -205,6 +200,7 @@ class MesaData:
             self.file_name,
             skip_header=MesaData.bulk_names_line - 1,
             names=True,
+            ndmin=1,  # Make sure a single entry is still a 1D array
             dtype=None,
         )
         self.bulk_names = self.bulk_data.dtype.names
@@ -591,7 +587,7 @@ class MesaData:
             True if `key` can be mapped to a data type either directly or by
             exponentiating/taking logarithms of existing data types
         """
-        return bool(
+        return (
             self.in_data(key)
             or self._log_version(key)
             or self._ln_version(key)


### PR DESCRIPTION
Fixed issue #18.

According to the issue, `MesaData` crashes whenever `history.data` contains a single entry. For example, this code:
```python
import mesa_reader as mr

h = mr.MesaData("history.data")
print(h.data("star_age"))
```
crashes with this `history.data` example:
```
                                       1                                        2                                        3                                        4                                        5                                        6                                        7                                        8                                        9                                       10                                       11 
                          version_number                                 compiler                                    build                         MESA_SDK_version                             math_backend                                     date                                burn_min1                                burn_min2                                     msun                                     rsun                                     lsun 
                              "r24.08.1"                               "gfortran"                                 "13.3.0"                    "x86_64-linux-24.7.1"                                 "CRMATH"                               "20241010"                  5.0000000000000000E+001                  1.0000000000000000E+003                  1.9884098706980504E+033                  6.9570000000000000E+010                  3.8280000000000003E+033 

                                       1                                        2                                        3                                        4                                        5                                        6                                        7                                        8                                        9                                       10                                       11                                       12                                       13                                       14                                       15                                       16                                       17                                       18                                       19                                       20                                       21                                       22                                       23                                       24                                       25                                       26                                       27                                       28                                       29                                       30                                       31                                       32                                       33                                       34                                       35                                       36                                       37                                       38                                       39                                       40                                       41                                       42                                       43                                       44                                       45                                       46                                       47                                       48                                       49                                       50                                       51                                       52                                       53                                       54                                       55                                       56                                       57                                       58                                       59                                       60                                       61                                       62                                       63                                       64                                       65                                       66                                       67                                       68                                       69                                       70                                       71                                       72                                       73                                       74                                       75                                       76                                       77                                       78                                       79                                       80 
                            model_number                                num_zones                                 star_age                                   log_dt                                star_mass                               log_xmstar                             log_abs_mdot                           mass_conv_core                             conv_mx1_top                             conv_mx1_bot                             conv_mx2_top                             conv_mx2_bot                                  mx1_top                                  mx1_bot                                  mx2_top                                  mx2_bot                                   log_LH                                  log_LHe                                   log_LZ                                 log_Lnuc                                       pp                                      cno                                tri_alpha                               epsnuc_M_1                               epsnuc_M_2                               epsnuc_M_3                               epsnuc_M_4                               epsnuc_M_5                               epsnuc_M_6                               epsnuc_M_7                               epsnuc_M_8                             he_core_mass                             co_core_mass                            one_core_mass                             fe_core_mass                   neutron_rich_core_mass                             kh_timescale                                 log_Teff                                    log_L                                    log_R                                    log_g                        v_div_csound_surf                           surf_avg_j_rot                           surf_avg_omega                      surf_avg_omega_crit            surf_avg_omega_div_omega_crit                           surf_avg_v_rot                          surf_avg_v_crit                    surf_avg_v_div_v_crit                   surf_avg_Lrad_div_Ledd                log_rotational_mdot_boost                             log_center_T                           log_center_Rho                             log_center_P                               log_cntr_P                             log_cntr_Rho                               log_cntr_T                                center_mu                                center_ye                              center_abar                           center_entropy                             center_omega              center_omega_div_omega_crit                                center_h1                               center_he4                               center_c12                               center_o16                              surface_c12                              surface_o16                            total_mass_h1                           total_mass_he4                                rel_E_err                            log_rel_E_err                        log_rel_run_E_err                         virial_thm_P_avg                       virial_thm_rel_err               log_total_angular_momentum                              num_retries                                num_iters                    num_solver_iterations 
                                       1                                      701                  1.0000000000000001E-005                 -4.9999999999999991E+000                  1.0000000000000000E+000                  3.3298505910360667E+001                 -9.8999999999999986E+001                  0.0000000000000000E+000                  9.9999999926399996E-001                  4.3057387872430443E-002                  0.0000000000000000E+000                  0.0000000000000000E+000                  9.9999999926399996E-001                  4.3057387872430443E-002                  0.0000000000000000E+000                  0.0000000000000000E+000                 -4.9256836675538498E+000                 -9.8999999999999986E+001                 -9.8999999999999986E+001                 -4.9256836675538498E+000                 -4.9256836676638729E+000                 -1.4521986232628695E+001                 -9.8999999999999986E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                 -2.0000000000000000E+001                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  1.1264944443851322E+007                  3.6416908966412245E+000                  5.3986990945158145E-002                  2.6626486305462616E-001                  3.9055379011938807E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                  0.0000000000000000E+000                 -9.8999999999999986E+001                  6.6225825279087402E+000                  1.4483780738109878E-001                  1.4891917203161618E+001                  1.4891917203161618E+001                  1.4483780738109878E-001                  6.6225825279087402E+000                  6.2123283091533743E-001                  8.5000496627254196E-001                  1.2966429887659305E+000                  1.9140691887791196E+001                  0.0000000000000000E+000                  0.0000000000000000E+000                  7.0000000000000018E-001                  2.7997020236474890E-001                  3.4468833607861297E-003                  9.3805276451495428E-003                  3.4468833607861288E-003                  9.3805276451495393E-003                  7.0000000000000029E-001                  2.7997020236474884E-001                  3.1437958614224491E-013                 -1.2502545662103401E+001                 -1.2502545662103401E+001                  1.7782034437464952E+048                  6.3606882070518757E-010                 -9.8999999999999986E+001                                        0                                        4                                        4 

```
The problem was that the numpy function `np.genfromtxt` returns a scalar if the data contains a single entry, but we want a 1D array with a single element instead. This function has a parameter `ndmin` which specifies the minimun number of dimensions for the output, so specifying `ndmin=1` ensures we get a 1D array even if we have a single entry which could be squeezed into a scalar.

With the changes I made, the same example code with the same example `history.data` prints the desired result `[1.e-05]`.