### PR TITLE
Optimize MesaData.read_log_data() and MesaData.remove_backups()

### DIFF
--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -238,10 +238,12 @@ class MesaData:
                 file.readline()
 
             self.bulk_names = file.readline().split(None, -1)
-            data_elements = file.readline().split(None, -1)
 
+            data_elements = file.readline().split(None, -1)
             data_types = self._get_dtype(self.bulk_names, data_elements)
 
+            # rewind & read data
+            file.seek(0)
             self.bulk_data = np.loadtxt(file, dtype=data_types, skiprows=MesaData.bulk_names_line)
 
         self.header_data = dict(zip(self.header_names, header_data))

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -238,7 +238,7 @@ class MesaData:
             self.bulk_names = file.readline().split(None, -1)
             data_elements = file.readline().split(None, -1)
 
-            data_types = self.get_dtype(self.bulk_names, data_elements)
+            data_types = self._get_dtype(self.bulk_names, data_elements)
 
             self.bulk_data = np.loadtxt(file, dtype=data_types, skiprows=MesaData.bulk_names_line)
 

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -732,7 +732,7 @@ class MesaData:
         if dbg:
             print("Scrubbing history...")
 
-        model_numbers = DataFrame(self.data["model_number"])
+        model_numbers = DataFrame(self.data("model_number"))
         kept_indices = model_numbers.drop_duplicates(keep="last").index
         
         if len(model_numbers) - len(kept_indices) == 0:

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -169,6 +169,8 @@ class MesaData:
             except ValueError:
                 if record == "NaN":
                     types.append((names[i], 'float64'))
+                if record.lower() in ["true", "false"]:
+                    types.append((names[i], '?'))
                 elif type(record) == str:
                     types.append((names[i], 'U128'))
         

--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -239,12 +239,17 @@ class MesaData:
 
             self.bulk_names = file.readline().split(None, -1)
 
+            pos_0 = file.tell()
             data_elements = file.readline().split(None, -1)
+            pos_1 = file.tell()
+            pos_diff = pos_1 - pos_0 # length of data line 1
+
             data_types = self._get_dtype(self.bulk_names, data_elements)
 
             # rewind & read data
-            file.seek(0)
-            self.bulk_data = np.loadtxt(file, dtype=data_types, skiprows=MesaData.bulk_names_line)
+            file.seek(-pos_diff)
+            self.bulk_data = np.fromfile(file, dtype=data_types, sep=" ")
+            #self.bulk_data = np.loadtxt(file, dtype=data_types, skiprows=MesaData.bulk_names_line)
 
         self.header_data = dict(zip(self.header_names, header_data))
         self.remove_backups()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(name='mesa_reader',
     author_email='wolfwm@uwec.edu',
     license='MIT',
     packages=['mesa_reader'],
-    install_requires=['numpy'],
+    install_requires=['numpy', 'pandas'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Hi Bill,

I've been using mesa_reader to handle very large grids of stars(~1000 individual runs adding up to tens of GiB) for my work, and I felt tempted to optimize the file loading/parsing procedure.

Using `numpy.genfromtxt()` (or `numpy.loadtxt()` for that matter) runs into pitfalls for large files, as it parses each line in python and concatenates the records into lists before forming the ndarray at the end. Having unknown data-types at runtime adds extra overhead (as in genfromtxt). I switched it to use `pandas.read_csv()`, which is substantially faster. I wrote a simple parser for the first data line to determine the data types for each column, so it should handle floats, ints, nans, and logicals just fine.

Similarly, implementing `pandas.DataFrame.drop_duplicates()` in the remove_backups method gives a modest speed increase.

As far as my testing has found, the output of this should be exactly the same, but I do not know how it would handle, say, an incomplete line (if you managed to open a log file mid-write).

Some simple profiling with a test grid (84 history files, ~600 MiB) shows a pretty good speed increase, especially if you have an SSD and are not limited by storage speed:

### genfromtxt method (last commit)

```
         47863545 function calls (47838824 primitive calls) in 28.949 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   28.975   28.975 /home/duncan_m/Projects/sample_history/mesa_test.py:11(test)
       84    0.000    0.000   28.975    0.345 /home/duncan_m/.conda/envs/sci/lib/python3.11/site-packages/mesa_reader/__init__.py:103(__init__)
       84    0.001    0.000   28.975    0.345 /home/duncan_m/.conda/envs/sci/lib/python3.11/site-packages/mesa_reader/__init__.py:152(read_data)
  ---> 84    0.451    0.005   28.974    0.345 /home/duncan_m/.conda/envs/sci/lib/python3.11/site-packages/mesa_reader/__init__.py:187(read_log_data)
...
  ---> 84    0.198    0.002    1.004    0.012 /home/duncan_m/.conda/envs/sci/lib/python3.11/site-packages/mesa_reader/__init__.py:673(remove_backups)
```

### read_csv method (this PR)

```
         3814731 function calls (3747761 primitive calls) in 6.821 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    6.821    6.821 /home/duncan_m/Projects/sample_history/mesa_test.py:11(test)
       84    0.000    0.000    6.821    0.081 /home/duncan_m/.conda/envs/sci-test/lib/python3.12/site-packages/mesa_reader/__init__.py:105(__init__)
       84    0.003    0.000    6.821    0.081 /home/duncan_m/.conda/envs/sci-test/lib/python3.12/site-packages/mesa_reader/__init__.py:182(read_data)
  ---> 84    0.007    0.000    6.817    0.081 /home/duncan_m/.conda/envs/sci-test/lib/python3.12/site-packages/mesa_reader/__init__.py:217(read_log_data)**
...
  ---> 84    0.121    0.001    0.187    0.002 /home/duncan_m/.conda/envs/sci-test/lib/python3.12/site-packages/mesa_reader/__init__.py:714(remove_backups)
```

For my particular test and system, the speedup is around 400%. :)

However, this method does require adding pandas as a dependency, which may not necessarily be desirable.