### PR TITLE
fix: handle logarithm/exponentiation of luminosity

### DIFF
--- a/mesa_reader/__init__.py
+++ b/mesa_reader/__init__.py
@@ -496,6 +496,8 @@ class MesaData:
             The "logified" version of the key, if available. If unavailable,
             `None`.
         """
+        if key=="luminosity" and self.in_data("log_L"):
+            return "log_L"
         log_prefixes = ["log_", "log", "lg_", "lg"]
         for prefix in log_prefixes:
             if self.in_data(prefix + key):
@@ -541,6 +543,8 @@ class MesaData:
         str or `None`
             The linear version of the key, if available. If unavailable, `None`.
         """
+        if key=="log_L" and self.in_data("luminosity"):
+            return "luminosity"
         log_matcher = re.compile(r"^lo?g_?(.+)")
         matches = log_matcher.match(key)
         if matches is not None:


### PR DESCRIPTION
I stumbled upon an issue with the "luminosity" value not being treated correctly, and tried to solve it:

The history_colums.list does not include the non-logarithmic luminosity as "L", but as "luminosity". Because of this, the usual treatment of logarithmic and non-logarithmic values does not work, necessitating an explicit case for catching this. While the value "L" is available in the profile_columns.list, it coexists with "luminosity" there, leading to potential problems should anyone use this column title.

This patch fixes this by explicitly checking for the existence of "luminosity" in the log files in the case of a key error that could not be resolved by the other cases specified, or "log_L" should "luminosity" be asked for but not found.

I am looking forward to feedback on this, best,
Lucas