### PR TITLE
Build and deploy docs on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+# Build the Sphinx documentation and publish it to GitHub Pages whenever a
+# release is published (the same trigger used to publish to PyPI), so the docs
+# track each released version rather than every push.
+
+name: docs
+
+on:
+  release:
+    types: [published]
+  # Allow a manual rebuild from the Actions tab without cutting a release.
+  workflow_dispatch:
+
+# Permissions required by actions/deploy-pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment; don't cancel an in-progress one.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          # autodoc imports mesa_reader, so the package and its runtime deps
+          # must be installed alongside the documentation tooling.
+          pip install .
+          pip install -r requirements-docs.txt
+      - name: Build HTML docs
+        run: sphinx-build -b html docs_source _site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ make.bat
 *.egg-info
 .buildinfo
 .vscode
+.venv
+.pytest_cache
+_site
+docs_build

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx_rtd_theme
+sphinx-copybutton


### PR DESCRIPTION
## Problem

The Sphinx docs under `docs/` are **not** regenerated automatically — there's no docs workflow, and GitHub Pages just serves the committed HTML. That HTML is a **static 2017 snapshot** (last built in `d11dd4c`), so the published docs are missing years of features (`.mod` model reading, the `file_type` param, pickle support, etc.). They don't reflect current docstrings.

## Fix

Add a `docs` workflow that rebuilds the docs from docstrings (`sphinx.ext.autodoc`) and deploys to GitHub Pages **on release publication** — the same trigger as the existing PyPI publish workflow — so the docs track each released version rather than churning on every push. Manual `workflow_dispatch` is also supported for an on-demand rebuild.

- `requirements-docs.txt` pins the doc toolchain (`sphinx`, `sphinx_rtd_theme`, `sphinx-copybutton`).
- The build command (`sphinx-build -b html docs_source _site`) was verified locally — builds cleanly and reflects current docstrings.

## ⚠️ Required one-time setup

This uses `actions/deploy-pages`, so the repo's Pages source must be switched from **"Deploy from a branch" (`/docs`)** to **"GitHub Actions"** under **Settings → Pages**. Until that's flipped, the `deploy` job will fail. (I can do this via `gh api` if you'd like — just say so.)

## Follow-ups (not in this PR)

- Once Pages deploys from Actions, the committed `docs/` HTML becomes vestigial and could be removed from the repo.
- The `version`/`release` in `docs_source/conf.py` (3.5.0) is stale vs `setup.py` (0.3.5) and could be wired to the package version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)